### PR TITLE
Security fix + packages fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,15 @@ RUN python3 -m pip install passlib
 RUN mkdir /credentials
 COPY htpasswd.txt credentials/htpasswd.txt
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 COPY Packages.txt /packages.txt
 ENV SERVED_PACKAGES_DIRECTORY=/root/packages
 RUN mkdir $SERVED_PACKAGES_DIRECTORY
 RUN echo "" > $SERVED_PACKAGES_DIRECTORY/__init__.py
 RUN export PYTHONPATH="${PYTHONPATH}:$SERVED_PACKAGES_DIRECTORY"
 COPY --from=package-dowloader /home/jovyan/packages $SERVED_PACKAGES_DIRECTORY
-RUN chmod +x /entrypoint.sh
+RUN chmod 444 $SERVED_PACKAGES_DIRECTORY
+USER guest
 
 EXPOSE 8080
 

--- a/Packages.txt
+++ b/Packages.txt
@@ -33,6 +33,6 @@ nbdev
 fastcore
 fastai
 tensorflow
-keras
+Keras
 progress
 progressbar2

--- a/Packages.txt
+++ b/Packages.txt
@@ -1,6 +1,7 @@
 numpy
 pandas
-pandas==1.2.0
+pandas==1.1.*
+koalas
 jupyterlab-git
 nbdime
 nbstripout
@@ -23,7 +24,7 @@ fuzzywuzzy[speedup]
 scikit-learn
 statsmodels
 matplotlib
-seaborne
+seaborn
 plotly
 ssb-spark-tools
 nltk
@@ -32,6 +33,6 @@ nbdev
 fastcore
 fastai
 tensorflow
-Keras
+keras
 progress
 progressbar2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "*** launching pypi-server with packages served from $SERVED_PACKAGES_DIRECTORY"
-pypi-server --disable-fallback -P credentials/htpasswd.txt -a update,download -d "$SERVED_PACKAGES_DIRECTORY"
-echo "*** pypi-server launched! ***"
+pypi-server --disable-fallback -P credentials/htpasswd.txt -a update,download -d "$SERVED_PACKAGES_DIRECTORY" "$SERVED_PACKAGES_DIRECTORY"
+echo "*** this print is after the 'pypi-server' command ***"


### PR DESCRIPTION
## Security fixes

### Non-root user owns packages and runs server
In order to eliminate the security risk of running everything as "root" user we create a new Linux user in the Docker container that is responsible for running the server and owns the "packages" folder. 

### Blocking package uploads
It was identified as a security risk that anyone with any password could upload or update packages on the server, because that would allow malicious actors to inject dirty code posing as trusted libraries. This is a security issue because all jupyterlab users have access to their common pypiserver password from inside the jupyterlab environment. I didn't find a way for us to configure it so that a given user of the pypiserver has download access but **not** upload access. I also did not find a way to turn off uploads completely for the pypiserver.

Because open uploads are currently a security issue, I found a hacky way of turning off uploads for everyone: The new linux user that now runs the server does not have write access to the "packages" folder. This means the server can't fulfill upload requests. Any attempt to upload new packages to the pypiserver will give a HTTP 500 Internal Server Error due to the failed disk write attempt, when it would be more appropriate if it gave HTTP 403 Forbidden. This is far from optimal, but at least it maintains security, which should be a priority.

#### Future improvements
One way to secure against malicious package uploads in the future (while also enabling package uploads from our users) would be to find a secure way for jupyterlab and dapla-pypiserver to communicate that did not require dapla-pypiserver to have the "exposed: true" configuration. If dapla-pypiserver was only reachable from jupyterlab and things running on BIP, uploads being open to all users with a password might be acceptable. However, since JupyterLab is outside the service mesh, this is easier said than done. It seems like the struggles I'm facing here are both due to lack of granular user access control on pypiserver AND due to the immaturity of BIP.
 
## Packages fixes
Fix typo in package name `seaborn`
Add `koalas` to the whitelist. It's present in the JupyterLab instances, so the pypiserver should have it and all its dependencies available too.