### PR TITLE
azure pipeline trigger on tag, but only build img on main

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -4,6 +4,9 @@ trigger:
   branches:
     include:
       - 'main'
+  tags:
+    include:
+      - '*'
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -18,6 +21,8 @@ variables:
     value: 'prod-bip/ssb/dapla/dapla-pypiserver'
   - name: DOCKER_BUILDKIT
     value: 1
+  - name: isMain
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 
 resources:
   repositories:
@@ -29,6 +34,7 @@ resources:
 
 jobs:
   - job: buildAndPush
+    condition: eq(variables.isMain, true)
     displayName: 'build and push Dockerimage'
     steps:
       - template: 'docker/docker-build-image-and-push-to-gcr.yml@templates'


### PR DESCRIPTION
I want this azure pipeline to trigger whenever a new tag is created, but only build a new image when a new commit is made to "main". In other words, when the pipeline runs on a tag, I want it to skip building and go straight to the "docker tag for production" job.

The way it worked before is I had to manually trigger building on tags in order to "tag for production", and it would also uselesly build a new image from the same code that would not be used.