### PR TITLE
build should trigger on pull requests too

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -34,7 +34,7 @@ resources:
 
 jobs:
   - job: buildAndPush
-    condition: eq(variables.isMain, true)
+    condition: eq(False, startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
     displayName: 'build and push Dockerimage'
     steps:
       - template: 'docker/docker-build-image-and-push-to-gcr.yml@templates'


### PR DESCRIPTION
Triggering build only on main is wrong, because pull requests to main also need to trigger builds