### PR TITLE
patch typo I SSB Spark tools

### DIFF
--- a/Packages.txt
+++ b/Packages.txt
@@ -56,7 +56,7 @@ ssb-ipython-kernels==0.2.22
 ssb-ipython-kernels==0.2.28
 ssb-ipython-kernels==0.2.32
 ssb-ipython-kernels==0.3.1
-ssb-spark-tools
+ssb_spark_tools
 ssb_spark_tools==0.1.1
 ssb_spark_tools==0.1.3
 statsmodels


### PR DESCRIPTION
Korrigert typo I sst_spark_tools, som gjorde at den ikke autowhitelisted nyeste versjon av biblioteket.
var skrevet med `-` ikke `_`